### PR TITLE
Adjust analysis manifest

### DIFF
--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/META-INF/MANIFEST.MF
@@ -21,4 +21,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.24.0",
 Export-Package: org.palladiosimulator.dataflow.confidentiality.analysis,
  org.palladiosimulator.dataflow.confidentiality.analysis.dsl,
  org.palladiosimulator.dataflow.confidentiality.analysis.sequence.entity,
- org.palladiosimulator.dataflow.confidentiality.analysis.sequence.entity.pcm
+ org.palladiosimulator.dataflow.confidentiality.analysis.sequence.entity.pcm,
+ org.palladiosimulator.dataflow.confidentiality.analysis.sequence.pcm


### PR DESCRIPTION
Exports the package `org.palladiosimulator.dataflow.confidentiality.analysis.sequence.pcm` for external use.