### PR TITLE
Add Branching to SEFF Elements

### DIFF
--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequence/entity/pcm/SEFFActionSequenceElement.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequence/entity/pcm/SEFFActionSequenceElement.java
@@ -16,9 +16,12 @@ import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.parameter.VariableCharacterisation;
 import org.palladiosimulator.pcm.repository.Parameter;
 import org.palladiosimulator.pcm.seff.AbstractAction;
+import org.palladiosimulator.pcm.seff.AbstractBranchTransition;
+import org.palladiosimulator.pcm.seff.BranchAction;
 import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
 import org.palladiosimulator.pcm.seff.SetVariableAction;
 import org.palladiosimulator.pcm.seff.StartAction;
+import org.palladiosimulator.pcm.usagemodel.BranchTransition;
 
 public class SEFFActionSequenceElement<T extends AbstractAction> extends AbstractPCMActionSequenceElement<T> {
 	private final Logger logger = Logger.getLogger(SEFFActionSequenceElement.class);
@@ -85,6 +88,15 @@ public class SEFFActionSequenceElement<T extends AbstractAction> extends Abstrac
     public List<Parameter> getParameter() {
 		return parameter;
 	}
+    
+    /**
+     * Returns whether a SEFF Action Sequence Element (i.e. Start Action) was created due to branching behavior
+     * @return Returns true, if the SEFF Action was created, because branching behavior was defined. Otherwise, the method returns false.
+     */
+    public boolean isBranching() {
+    	Optional<BranchAction> branchAction = PCMQueryUtils.findParentOfType(this.getElement(), BranchAction.class, false);
+    	return branchAction.isPresent();
+    }
 
     @Override
     public String toString() {
@@ -93,6 +105,11 @@ public class SEFFActionSequenceElement<T extends AbstractAction> extends Abstrac
     		Optional<ResourceDemandingSEFF> seff = PCMQueryUtils.findParentOfType(this.getElement(), ResourceDemandingSEFF.class, false);
     		if (seff.isPresent()) {
     			elementName = "Beginning " + seff.get().getDescribedService__SEFF().getEntityName();
+    		}
+    		if (this.isBranching()) {
+    			Optional<BranchAction> branchAction = PCMQueryUtils.findParentOfType(this.getElement(), BranchAction.class, false);
+    			Optional<AbstractBranchTransition> branchTransition = PCMQueryUtils.findParentOfType(this.getElement(), AbstractBranchTransition.class, false);
+    			elementName = "Branching " + seff.get().getDescribedService__SEFF().getEntityName() + "." + branchAction.get().getEntityName() + "." +  branchTransition.get().getEntityName();
     		}
     	}
         return String.format("%s (%s, %s))", this.getClass()

--- a/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequencefinder/ActionSequenceFinderTest.java
+++ b/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequencefinder/ActionSequenceFinderTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.log4j.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,6 +19,7 @@ import org.palladiosimulator.dataflow.confidentiality.analysis.BaseTest;
 import org.palladiosimulator.dataflow.confidentiality.analysis.StandalonePCMDataFlowConfidentialtyAnalysis;
 
 public class ActionSequenceFinderTest extends BaseTest {
+	private final Logger logger = Logger.getLogger(ActionSequenceFinderTest.class);
 
     /**
      * Tests whether the analysis finds the correct amount of sequences
@@ -34,6 +36,7 @@ public class ActionSequenceFinderTest extends BaseTest {
         var allSequences = analysis.findAllSequences();
         assertEquals(expectedSequences, allSequences.size(),
                 String.format("Expected two dataflow sequences, but found %s sequences", allSequences.size()));
+        allSequences.stream().forEach(System.out::println);
     }
 
     /**

--- a/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequencefinder/ActionSequenceFinderTest.java
+++ b/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/sequencefinder/ActionSequenceFinderTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -34,9 +35,10 @@ public class ActionSequenceFinderTest extends BaseTest {
     @MethodSource("testCountProvider")
     public void testCount(StandalonePCMDataFlowConfidentialtyAnalysis analysis, int expectedSequences) {
         var allSequences = analysis.findAllSequences();
+        analysis.setLoggerLevel(Level.TRACE);
         assertEquals(expectedSequences, allSequences.size(),
                 String.format("Expected two dataflow sequences, but found %s sequences", allSequences.size()));
-        allSequences.stream().forEach(System.out::println);
+        allSequences.stream().forEach(logger::trace);
     }
 
     /**


### PR DESCRIPTION
This PR adds the method `isBranching()` to SEFFActionSequenceElements, which determine, whether a SEFF Sequence Element (i.e. StartAction for now) was created due to Branching Behavior in the Model.

This PR closes #37 