### PR TITLE
Fix typo in analysis. Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ public class Main {
     DataFlowConfidentialityAnalysis analysis = new DataFlowAnalysisBuilder()
         .standalone()
         .modelProjectName("<PROJECT_NAME>")
-        .registerBuilder(new PCMDataFlowConfidentialityAnalysisBuilder())
-        .registerPluginActivator(Activator.class)
-        .registerUsageModel("<USAGE_MODEL_PATH>")
-        .registerAllocationModel("<ALLOCATION_MODEL_PATH>")
-    	.registerNodeCharacteristicsModel("<NODE_MODEL_PATH>")
+        .useBuilder(new PCMDataFlowConfidentialityAnalysisBuilder())
+        .usePluginActivator(Activator.class)
+        .useUsageModel("<USAGE_MODEL_PATH>")
+        .useAllocationModel("<ALLOCATION_MODEL_PATH>")
+        .useNodeCharacteristicsModel("<NODE_MODEL_PATH>")
         .build();
+
     analysis.setLoggerLevel(Logger.TRACE); // Set desired logger level. Level.TRACE provides additional propagation Information
     analysis.initializeAnalysis();
 

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/DataFlowConfidentialityAnalysis.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/DataFlowConfidentialityAnalysis.java
@@ -9,7 +9,7 @@ import org.palladiosimulator.dataflow.confidentiality.analysis.entity.sequence.A
 
 public interface DataFlowConfidentialityAnalysis {
 
-    public boolean initalizeAnalysis();
+    public boolean initializeAnalysis();
 
     public List<ActionSequence> findAllSequences();
 

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/core/AbstractStandalonePCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/core/AbstractStandalonePCMDataFlowConfidentialityAnalysis.java
@@ -98,7 +98,7 @@ public abstract class AbstractStandalonePCMDataFlowConfidentialityAnalysis imple
 	}
 	
 	@Override
-    public boolean initalizeAnalysis() {
+    public boolean initializeAnalysis() {
         if (initStandaloneAnalysis()) {
             logger.info("Successfully initialized standalone data flow analysis.");
         } else {

--- a/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/BaseTest.java
+++ b/tests/org.palladiosimulator.dataflow.confidentiality.analysis.tests/src/org/palladiosimulator/dataflow/confidentiality/analysis/BaseTest.java
@@ -35,7 +35,7 @@ public class BaseTest {
         		.useAllocationModel(allocationPath)
         		.build();
 
-        onlineShopAnalysis.initalizeAnalysis();
+        onlineShopAnalysis.initializeAnalysis();
     }
 
     @BeforeAll
@@ -54,7 +54,7 @@ public class BaseTest {
         		.useAllocationModel(allocationPath)
         		.build();
 
-        internationalOnlineShopAnalysis.initalizeAnalysis();
+        internationalOnlineShopAnalysis.initializeAnalysis();
     }
 
     @BeforeAll
@@ -73,7 +73,7 @@ public class BaseTest {
         		.useUsageModel(usageModelPath)
         		.useAllocationModel(allocationPath)
         		.build();
-        travelPlannerAnalysis.initalizeAnalysis();
+        travelPlannerAnalysis.initializeAnalysis();
     }
     
     protected DataFlowConfidentialityAnalysis initializeAnalysis(Path usagePath, Path allocationPath) {
@@ -86,7 +86,7 @@ public class BaseTest {
     			.useUsageModel(usagePath.toString())
     			.useAllocationModel(allocationPath.toString())
     			.build();
-    	analysis.initalizeAnalysis();
+    	analysis.initializeAnalysis();
     	return analysis;
     }
     
@@ -100,7 +100,7 @@ public class BaseTest {
     			.useAllocationModel(allocationPath.toString())
     			.useNodeCharacteristicsModel(nodePath.toString())
     			.build();
-    	analysis.initalizeAnalysis();
+    	analysis.initializeAnalysis();
     	return analysis;
     }
 }


### PR DESCRIPTION
Fix typo in function `initializeAnalysis`. Update README to reflect the changes after the code review of #52.