### PR TITLE
Update and rename build.yml to main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,9 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Palladio-Addons-DataFlowConfidentiality-Analysis:
-    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.3
+    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.4
     with:
       use-display-output: true
-      runner-label: ubuntu-latest
       no-caching: true
       java-version: 17
       deploy-updatesite: 'releng/org.palladiosimulator.dataflow.confidentiality.pcm.analysis.updatesite/target/repository'


### PR DESCRIPTION
This update is part of the new [dynamic build pipeline](https://github.com/PalladioSimulator/Palladio-Build-Nightly/pull/12) for nightly builds.

As discussed with @Nicolas-Boltz @larissaschmid 
- Updated to https://github.com/PalladioSimulator/Palladio-Build-ActionsPipeline/releases/tag/v3.4
- Removed runner label
- Rename build file to opt-out of the nightly build