### PR TITLE
Export analysis utils.

### DIFF
--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/META-INF/MANIFEST.MF
@@ -30,4 +30,5 @@ Export-Package: org.palladiosimulator.dataflow.confidentiality.analysis,
  org.palladiosimulator.dataflow.confidentiality.analysis.entity.pcm.user,
  org.palladiosimulator.dataflow.confidentiality.analysis.entity.sequence,
  org.palladiosimulator.dataflow.confidentiality.analysis.resource,
- org.palladiosimulator.dataflow.confidentiality.analysis.sequence.pcm
+ org.palladiosimulator.dataflow.confidentiality.analysis.sequence.pcm,
+ org.palladiosimulator.dataflow.confidentiality.analysis.utils.pcm


### PR DESCRIPTION
Add the `utils.pcm` package to the exported packages of the analysis.