### PR TITLE
Add Node Characteristic and Resource Validation to Builder

### DIFF
--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/LegacyPCMNodeCharacteristicsCalculator.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/LegacyPCMNodeCharacteristicsCalculator.java
@@ -131,4 +131,9 @@ public class LegacyPCMNodeCharacteristicsCalculator implements NodeCharacteristi
     	}
     	return nodeCharacteristics;
     }
+
+	@Override
+	public void checkAssignments() {
+		// Not implemented, as legacy node assignments will not be checked beforehand
+	}
 }

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/NodeCharacteristicsCalculator.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/NodeCharacteristicsCalculator.java
@@ -8,5 +8,17 @@ import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.core.entity.Entity;
 
 public interface NodeCharacteristicsCalculator {
+	/**
+	 * Returns a list of applied node characteristics at the given node in the given assembly context
+	 * @param node Node of whom the characteristics will be calculated
+	 * @param context Assembly context applicable to the node
+	 * @return Returns a list of node characteristics (i.e. characteristic type and literal) that are applied at that node
+	 */
 	public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context);
+	
+	/**
+	 * Checks the given list of assignments for errors or inconsistencies
+	 * @param assignments List of assignments that should be checked
+	 */
+	public void checkAssignments();
 }

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/PCMNodeCharacteristicsCalculator.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/characteristics/node/PCMNodeCharacteristicsCalculator.java
@@ -51,7 +51,6 @@ public class PCMNodeCharacteristicsCalculator implements NodeCharacteristicsCalc
 	@Override
 	public List<CharacteristicValue> getNodeCharacteristics(Entity node, Deque<AssemblyContext> context) {
 		Assignments assignments = this.resolveAssignments();
-		this.checkAssignments(assignments);
 		List<AbstractAssignee> assignees;
 		if (node instanceof AbstractUserAction) {
 			assignees = this.getUsage(node, assignments);
@@ -177,11 +176,9 @@ public class PCMNodeCharacteristicsCalculator implements NodeCharacteristicsCalc
 	            .findFirst().orElse(NodeCharacteristicsFactory.eINSTANCE.createAssignments());
 	}
 	
-	/**
-	 * Checks the given list of assignments for errors or inconsistencies
-	 * @param assignments List of assignments that should be checked
-	 */
-	private void checkAssignments(Assignments assignments) {
+	@Override
+	public void checkAssignments() {
+		Assignments assignments = this.resolveAssignments();
 		for (AbstractAssignee assignee : assignments.getAssignee()) {
 			if (assignee instanceof UsageAsignee) {
 				UsageAsignee usage = (UsageAsignee) assignee;

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/core/AbstractStandalonePCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/core/AbstractStandalonePCMDataFlowConfidentialityAnalysis.java
@@ -110,6 +110,8 @@ public abstract class AbstractStandalonePCMDataFlowConfidentialityAnalysis imple
         } else {
             throw new IllegalStateException("Failed loading the required models for the data flow analysis.");
         }
+        
+        this.analysisData.getNodeCharacteristicsCalculator().checkAssignments();
 
         return true;
     }

--- a/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/resource/ResourceLoader.java
+++ b/bundles/org.palladiosimulator.dataflow.confidentiality.analysis/src/org/palladiosimulator/dataflow/confidentiality/analysis/resource/ResourceLoader.java
@@ -5,6 +5,9 @@ import java.util.List;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.palladiosimulator.pcm.allocation.Allocation;
+import org.palladiosimulator.pcm.repository.RepositoryPackage;
+import org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentPackage;
+import org.palladiosimulator.pcm.system.SystemPackage;
 import org.palladiosimulator.pcm.usagemodel.UsageModel;
 
 public interface ResourceLoader {
@@ -32,4 +35,25 @@ public interface ResourceLoader {
 	 * @return Returns a list of objects that are of the target type
 	 */
 	public <T extends EObject> List<T> lookupElementOfType(final EClass targetType);
+	
+	
+	/**
+	 * Determines, whether the resource loader has sufficient resources to run the analysis
+	 * @return This method returns true, if the analysis can be executed with the resource loader. Otherwise, the method returns false
+	 */
+	public default boolean sufficientResourcesLoaded() {
+		if (this.getUsageModel() == null || this.getAllocation() == null) {
+			return false;
+		}
+		if (this.lookupElementOfType(RepositoryPackage.eINSTANCE.getRepository()).isEmpty()) {
+			return false;
+		}
+		if (this.lookupElementOfType(SystemPackage.eINSTANCE.getSystem()).isEmpty()) {
+			return false;
+		}
+		if (this.lookupElementOfType(ResourceenvironmentPackage.eINSTANCE.getResourceEnvironment()).isEmpty()) {
+			return false;
+		}
+		return true;
+	}
 }


### PR DESCRIPTION
This PR adds validation for node characteristics and preloaded resources to the analysis builder or the analysis itself.
It implements the following features
- Check preloaded resources (i, e, running the analysis with a List of loaded resources). Previously, an internal error could occur, if an important model (e.g. allocation or usage model) was missing. Now, users will receive an error while using the builder
- Check the node characteristics once before running the analysis (This step occurs during Initialization of the analysis, not in the builder, because resources are loaded during the initialization of the analysis and not before)

This PR closes #55 