### PR TITLE
Fix: Change DFD Finder to identify sinks if a input pin is unused

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -355,12 +355,11 @@ public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
                 })
                 .toList();
 
-        if (endNodes.isEmpty()) 
+        if (endNodes.isEmpty())
             throw new IllegalArgumentException("Error, sink cannot be identified!");
-        
+
         return endNodes;
     }
-
 
     public boolean hasCycles() {
         return hasCycles;


### PR DESCRIPTION
If a node used the inputs of a single input pin it was not identified as a sink. 

This is not desired behavior and needs to be fixed. 