### PR TITLE
Enforce no vertex to vertex DSL constraints

### DIFF
--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -236,6 +236,14 @@ public class AnalysisConstraint {
         if (!string.empty()) {
             return ParseResult.error("Unexpected symbols: " + string.getString());
         }
+        if (!vertexSourceSelectors.getSelectors()
+                .isEmpty()
+                && !vertexDestinationSelectors.getSelectors()
+                        .isEmpty()
+                && dataSourceSelectors.getSelectors()
+                        .isEmpty()) {
+            return ParseResult.error("Cannot create DSL constraint from purely vertex selectors! This behavior is not implemented yet!");
+        }
         return ParseResult.ok(
                 new AnalysisConstraint(name, vertexSourceSelectors, dataSourceSelectors, vertexDestinationSelectors, conditionalSelectors, context));
     }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -77,6 +77,13 @@ public class VertexTypeSelector extends VertexSelector {
                 .isEmpty()) {
             return ParseResult.error("Cannot parse vertex types without context provider!");
         }
+        if (inverted) {
+            string.advance(DSL_INVERTED_SYMBOL.length());
+        }
+        if (!string.startsWith(DSL_KEYWORD)) {
+            return string.expect(DSL_KEYWORD);
+        }
+        string.advance(DSL_KEYWORD.length() + 1);
         ParseResult<VertexType> vertexType = context.getContextProvider()
                 .get()
                 .vertexTypeFromString(string);

--- a/docs/wiki/dsl/index.md
+++ b/docs/wiki/dsl/index.md
@@ -73,6 +73,11 @@ data named secrets
 ## Destination Selectors 
 A **destination selector** describes the destination of a data flow though the system. 
 It selects nodes based on their vertex label or their vertex type.
+::: warning Warning 
+Currently using only vertex selectors for both source and destination is unsupported.
+When you want to match a node based on their vertex attributes, consider using just Vertex Source Selectors.
+If you want to find flows originating at a specific node and arriving at *another* node, see this [issue](https://github.com/DataFlowAnalysis/DataFlowAnalysis/issues/179)
+:::
 
 ### Vertex Selector
 To select nodes based on their label, one can use `vertex <Type>.<Value>` where `<Type>` describes a label type that must be present at a given node and `<Value>` must describe a label value of the defined label type that must be present at the node. 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
+import org.dataflowanalysis.analysis.dfd.dsl.DFDDSLContextProvider;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.AnalysisQuery;
 import org.dataflowanalysis.analysis.dsl.constraint.ConstraintDSL;
@@ -199,6 +200,13 @@ public class DSLResultTest extends BaseTest {
         assertEquals(constraint.toString(), AnalysisConstraint.fromString(new StringView(constraint.toString()))
                 .getResult()
                 .toString());
+    }
+
+    @Test
+    public void cannotParseOnlyVertexSelectors() {
+        ParseResult<AnalysisConstraint> constraint = AnalysisConstraint
+                .fromString(new StringView("- Test: vertex type PROCESS neverFlows vertex type STORE"), new DFDDSLContextProvider());
+        assertTrue(constraint.failed());
     }
 
     private void evaluateAnalysis(AnalysisConstraint constraint, DataFlowConfidentialityAnalysis analysis, List<ConstraintData> expectedResults) {


### PR DESCRIPTION
This PR enforces that DSL constraints cannot contain only vertex selectors in the source and destination of a DSL constraint.
Additionally, the user is informed that the behavior is implemented in a future version.

This PR adds:
- Enforcement of the above
- A test case verifying that a constraint with only source and destination vertex selectors cannot be parsed
- Slight modification in the documentation to point to the open GitHub issue