### PR TITLE
Add dedicated logging manager to manage log levels

### DIFF
--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDConfidentialityAnalysis.java
@@ -8,6 +8,7 @@ import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.core.DFDFlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import tools.mdsd.library.standalone.initialization.StandaloneInitializationException;
@@ -17,7 +18,7 @@ import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder
  * This class represents a toplevel dfd confidentiality analysis which allows analysis of a given model
  */
 public class DFDConfidentialityAnalysis extends DataFlowConfidentialityAnalysis {
-    private final Logger logger = Logger.getLogger(DFDConfidentialityAnalysis.class);
+    private final Logger logger = LoggerManager.getLogger(DFDConfidentialityAnalysis.class);
 
     protected final DFDResourceProvider resourceProvider;
     protected final Optional<Class<? extends Plugin>> modelProjectActivator;
@@ -79,6 +80,7 @@ public class DFDConfidentialityAnalysis extends DataFlowConfidentialityAnalysis 
 
     @Override
     public void setLoggerLevel(Level level) {
-        logger.setLevel(level);
+        LoggerManager.getInstance()
+                .setLevel(level);
     }
 }

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/DFDDataFlowAnalysisBuilder.java
@@ -8,6 +8,7 @@ import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDModelResourceProvider;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
 import org.dataflowanalysis.analysis.dfd.resource.DFDURIResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ResourceUtils;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.common.util.URI;
@@ -17,7 +18,7 @@ import org.eclipse.emf.common.util.URI;
  * validated, when calling {@link DFDDataFlowAnalysisBuilder#build()} before an analysis object is returned
  */
 public class DFDDataFlowAnalysisBuilder extends DataFlowAnalysisBuilder {
-    private final Logger logger = Logger.getLogger(DFDDataFlowAnalysisBuilder.class);
+    private final Logger logger = LoggerManager.getLogger(DFDDataFlowAnalysisBuilder.class);
 
     protected String dataFlowDiagramPath;
     protected String dataDictionaryPath;

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDFlowGraphCollection.java
@@ -8,12 +8,13 @@ import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
 import org.dataflowanalysis.analysis.dfd.simple.DFDSimpleTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 /**
  * This class represents a flow graph in a dfd model
  */
 public class DFDFlowGraphCollection extends FlowGraphCollection {
-    private final Logger logger = Logger.getLogger(DFDFlowGraphCollection.class);
+    private final Logger logger = LoggerManager.getLogger(DFDFlowGraphCollection.class);
 
     /**
      * Creates a new collection of flow graphs. {@link DFDFlowGraphCollection#initialize(ResourceProvider)} should be called

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/core/DFDTransposeFlowGraphFinder.java
@@ -5,6 +5,7 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.TransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.resource.DFDResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.dfd.datadictionary.AbstractAssignment;
 import org.dataflowanalysis.dfd.datadictionary.Assignment;
 import org.dataflowanalysis.dfd.datadictionary.Behavior;
@@ -19,7 +20,7 @@ import org.dataflowanalysis.dfd.dataflowdiagram.Node;
  * The DFDTransposeFlowGraphFinder determines all transpose flow graphs contained in a model
  */
 public class DFDTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
-    private final Logger logger = Logger.getLogger(TransposeFlowGraphFinder.class);
+    private final Logger logger = LoggerManager.getLogger(TransposeFlowGraphFinder.class);
     protected final DataFlowDiagram dataFlowDiagram;
     private boolean hasCycles = false;
 

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/interactive/DFDAnalysisCLI.java
@@ -12,13 +12,14 @@ import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 /**
  * This class is responsible for the interaction with the analysis via a command line interface (CLI)
  */
 public class DFDAnalysisCLI {
-    private static final Logger logger = Logger.getLogger(DFDAnalysisCLI.class);
+    private static final Logger logger = LoggerManager.getLogger(DFDAnalysisCLI.class);
     private static final String INPUT_INDICATOR = "> ";
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis.dfd/src/org/dataflowanalysis/analysis/dfd/resource/DFDURIResourceProvider.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.dfd.resource;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.dataflowdiagram.DataFlowDiagram;
 import org.eclipse.emf.common.util.URI;
@@ -14,7 +15,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
  * {@link URI}
  */
 public class DFDURIResourceProvider extends DFDResourceProvider {
-    private static final Logger logger = Logger.getLogger(DFDURIResourceProvider.class);
+    private static final Logger logger = LoggerManager.getLogger(DFDURIResourceProvider.class);
 
     private final URI dataFlowDiagramURI;
     private final URI dataDictionaryURI;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysis.java
@@ -10,6 +10,7 @@ import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.core.PCMFlowGraphCollection;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.pcm.extension.dddsl.DDDslStandaloneSetup;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.DictionaryPackage;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.dictionary.PCMDataDictionary;
@@ -24,7 +25,7 @@ import tools.mdsd.library.standalone.initialization.StandaloneInitializerBuilder
 
 public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityAnalysis {
     private static final String PLUGIN_PATH = "org.dataflowanalysis.analysis.pcm";
-    private final Logger logger;
+    private final Logger logger = LoggerManager.getLogger(PCMDataFlowConfidentialityAnalysis.class);
 
     protected final PCMResourceProvider resourceProvider;
 
@@ -42,7 +43,6 @@ public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityA
     public PCMDataFlowConfidentialityAnalysis(PCMResourceProvider resourceProvider, String modelProjectName,
             Optional<Class<? extends Plugin>> modelProjectActivator) {
         this.resourceProvider = resourceProvider;
-        this.logger = Logger.getLogger(PCMDataFlowConfidentialityAnalysis.class);
         this.modelProjectName = modelProjectName;
         this.modelProjectActivator = modelProjectActivator;
     }
@@ -80,6 +80,9 @@ public class PCMDataFlowConfidentialityAnalysis extends DataFlowConfidentialityA
         Logger.getLogger(ResourceSetBasedAllContainersStateProvider.class)
                 .setLevel(level);
         Logger.getLogger(AbstractCleaningLinker.class)
+                .setLevel(level);
+
+        LoggerManager.getInstance()
                 .setLevel(level);
     }
 

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/PCMDataFlowConfidentialityAnalysisBuilder.java
@@ -6,12 +6,13 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.pcm.resource.PCMURIResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ResourceUtils;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.emf.common.util.URI;
 
 public class PCMDataFlowConfidentialityAnalysisBuilder extends DataFlowAnalysisBuilder {
-    private final Logger logger = Logger.getLogger(PCMDataFlowConfidentialityAnalysisBuilder.class);
+    private final Logger logger = LoggerManager.getLogger(PCMDataFlowConfidentialityAnalysisBuilder.class);
 
     protected String relativeUsageModelPath;
     protected String relativeAllocationModelPath;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/AbstractPCMVertex.java
@@ -10,6 +10,7 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.ConfidentialityVariableCharacterisation;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.core.entity.Entity;
@@ -17,7 +18,7 @@ import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.repository.Parameter;
 
 public abstract class AbstractPCMVertex<T extends Entity> extends AbstractVertex<T> {
-    private final Logger logger = Logger.getLogger(AbstractPCMVertex.class);
+    private final Logger logger = LoggerManager.getLogger(AbstractPCMVertex.class);
 
     protected final Deque<AssemblyContext> context;
     protected final ResourceProvider resourceProvider;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMFlowGraphCollection.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMFlowGraphCollection.java
@@ -8,9 +8,10 @@ import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.pcm.core.finder.PCMTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 public class PCMFlowGraphCollection extends FlowGraphCollection {
-    private static final Logger logger = Logger.getLogger(PCMFlowGraphCollection.class);
+    private static final Logger logger = LoggerManager.getLogger(PCMFlowGraphCollection.class);
 
     public PCMFlowGraphCollection() {
 

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/PCMVertexCharacteristicsCalculator.java
@@ -11,6 +11,7 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.pcm.extension.dictionary.characterized.DataDictionaryCharacterized.Literal;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.characteristics.EnumCharacteristic;
 import org.dataflowanalysis.pcm.extension.nodecharacteristics.nodecharacteristics.AbstractAssignee;
@@ -40,7 +41,7 @@ import org.palladiosimulator.pcm.usagemodel.UsageScenario;
 import org.palladiosimulator.pcm.usagemodel.UsagemodelPackage;
 
 public class PCMVertexCharacteristicsCalculator {
-    private final Logger logger = Logger.getLogger(PCMVertexCharacteristicsCalculator.class);
+    private final Logger logger = LoggerManager.getLogger(PCMVertexCharacteristicsCalculator.class);
     private final ResourceProvider resourceLoader;
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMSEFFTransposeFlowGraphFinder.java
@@ -15,6 +15,7 @@ import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.pcm.utils.SEFFWithContext;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.repository.OperationRequiredRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
@@ -28,7 +29,7 @@ import org.palladiosimulator.pcm.seff.StartAction;
 import org.palladiosimulator.pcm.seff.StopAction;
 
 public class PCMSEFFTransposeFlowGraphFinder {
-    private static final Logger logger = Logger.getLogger(PCMSEFFTransposeFlowGraphFinder.class);
+    private static final Logger logger = LoggerManager.getLogger(PCMSEFFTransposeFlowGraphFinder.class);
 
     private final ResourceProvider resourceProvider;
     private final SEFFFinderContext context;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMTransposeFlowGraphFinder.java
@@ -10,6 +10,7 @@ import org.dataflowanalysis.analysis.pcm.core.PCMTransposeFlowGraph;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.repository.Parameter;
@@ -17,7 +18,7 @@ import org.palladiosimulator.pcm.seff.AbstractAction;
 import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
 
 public class PCMTransposeFlowGraphFinder implements TransposeFlowGraphFinder {
-    private final Logger logger = Logger.getLogger(PCMTransposeFlowGraphFinder.class);
+    private final Logger logger = LoggerManager.getLogger(PCMTransposeFlowGraphFinder.class);
 
     private final ResourceProvider resourceProvider;
     private final Collection<AssemblyContext> contexts;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserTransposeFlowGraphFinder.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/finder/PCMUserTransposeFlowGraphFinder.java
@@ -9,6 +9,7 @@ import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.pcm.utils.SEFFWithContext;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.palladiosimulator.pcm.core.entity.Entity;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
 import org.palladiosimulator.pcm.repository.OperationSignature;
@@ -21,7 +22,7 @@ import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.Stop;
 
 public class PCMUserTransposeFlowGraphFinder {
-    private static final Logger logger = Logger.getLogger(PCMUserTransposeFlowGraphFinder.class);
+    private static final Logger logger = LoggerManager.getLogger(PCMUserTransposeFlowGraphFinder.class);
 
     private final ResourceProvider resourceProvider;
     private PCMTransposeFlowGraph currentTransposeFlowGraph;

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/seff/SEFFPCMVertex.java
@@ -13,6 +13,7 @@ import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
 import org.dataflowanalysis.analysis.pcm.utils.PCMQueryUtils;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.pcm.extension.model.confidentiality.ConfidentialityVariableCharacterisation;
 import org.palladiosimulator.pcm.core.composition.AssemblyContext;
 import org.palladiosimulator.pcm.repository.Parameter;
@@ -25,7 +26,7 @@ import org.palladiosimulator.pcm.seff.StartAction;
 import org.palladiosimulator.pcm.seff.StopAction;
 
 public class SEFFPCMVertex<T extends AbstractAction> extends AbstractPCMVertex<T> {
-    private final Logger logger = Logger.getLogger(SEFFPCMVertex.class);
+    private final Logger logger = LoggerManager.getLogger(SEFFPCMVertex.class);
 
     private final List<Parameter> parameter;
 

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/core/user/UserPCMVertex.java
@@ -8,12 +8,13 @@ import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.pcm.core.AbstractPCMVertex;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.palladiosimulator.pcm.usagemodel.AbstractUserAction;
 import org.palladiosimulator.pcm.usagemodel.Start;
 import org.palladiosimulator.pcm.usagemodel.Stop;
 
 public class UserPCMVertex<T extends AbstractUserAction> extends AbstractPCMVertex<T> {
-    private final Logger logger = Logger.getLogger(UserPCMVertex.class);
+    private final Logger logger = LoggerManager.getLogger(UserPCMVertex.class);
 
     /**
      * Creates a new User Sequence Element with the given Palladio User Action Element

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/interactive/PCMAnalysisCLI.java
@@ -12,13 +12,14 @@ import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 /**
  * This class is responsible for the interaction with the analysis via a command line interface (CLI)
  */
 public class PCMAnalysisCLI {
-    private static final Logger logger = Logger.getLogger(PCMAnalysisCLI.class);
+    private static final Logger logger = LoggerManager.getLogger(PCMAnalysisCLI.class);
     private static final String INPUT_INDICATOR = "> ";
 
     /**

--- a/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/utils/PCMQueryUtils.java
+++ b/bundles/org.dataflowanalysis.analysis.pcm/src/org/dataflowanalysis/analysis/pcm/utils/PCMQueryUtils.java
@@ -17,6 +17,7 @@ import org.dataflowanalysis.analysis.pcm.core.seff.SEFFPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.resource.PCMResourceProvider;
 import org.dataflowanalysis.analysis.resource.ResourceProvider;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -56,7 +57,7 @@ import org.palladiosimulator.pcm.usagemodel.UsageModel;
 import org.palladiosimulator.pcm.usagemodel.UsageScenario;
 
 public class PCMQueryUtils {
-    private static final Logger logger = Logger.getLogger(PCMQueryUtils.class);
+    private static final Logger logger = LoggerManager.getLogger(PCMQueryUtils.class);
 
     private PCMQueryUtils() {
         throw new IllegalStateException("Utility classes should not be instantiated");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowAnalysisBuilder.java
@@ -1,7 +1,8 @@
 package org.dataflowanalysis.analysis;
 
 import java.util.Optional;
-import org.apache.log4j.*;
+import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.eclipse.core.runtime.Plugin;
 
 /**
@@ -11,7 +12,7 @@ import org.eclipse.core.runtime.Plugin;
  * in subclasses and validated via {@link DataFlowAnalysisBuilder#validate()}.
  */
 public abstract class DataFlowAnalysisBuilder {
-    private final Logger logger = Logger.getLogger(DataFlowAnalysisBuilder.class);
+    private final Logger logger = LoggerManager.getLogger(DataFlowAnalysisBuilder.class);
 
     protected boolean standalone;
     protected String modelProjectName;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowConfidentialityAnalysis.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/DataFlowConfidentialityAnalysis.java
@@ -7,6 +7,7 @@ import org.dataflowanalysis.analysis.core.AbstractTransposeFlowGraph;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.utils.ANSIConsoleLogger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.eclipse.xtext.linking.impl.AbstractCleaningLinker;
 import org.eclipse.xtext.linking.impl.DefaultLinkingService;
 import org.eclipse.xtext.parser.antlr.AbstractInternalAntlrParser;
@@ -22,7 +23,7 @@ import org.eclipse.xtext.resource.containers.ResourceSetBasedAllContainersStateP
  */
 public abstract class DataFlowConfidentialityAnalysis {
     public static final String PLUGIN_PATH = "org.dataflowanalysis.analysis";
-    private final Logger logger = Logger.getLogger(DataFlowConfidentialityAnalysis.class);
+    private final Logger logger = LoggerManager.getLogger(DataFlowConfidentialityAnalysis.class);
 
     /**
      * Initializes the analysis by setting up the execution environment and loading the referenced models
@@ -61,16 +62,15 @@ public abstract class DataFlowConfidentialityAnalysis {
      * Sets up the unified logging environment for the data flow analysis
      */
     protected void setupLoggers() {
-        BasicConfigurator.resetConfiguration();
         BasicConfigurator.configure(new ANSIConsoleLogger(new EnhancedPatternLayout("%-6r [%p] %-35C{1} - %m%n")));
 
-        Logger.getLogger(AbstractInternalAntlrParser.class)
+        LoggerManager.getLogger(AbstractInternalAntlrParser.class)
                 .setLevel(Level.WARN);
-        Logger.getLogger(DefaultLinkingService.class)
+        LoggerManager.getLogger(DefaultLinkingService.class)
                 .setLevel(Level.WARN);
-        Logger.getLogger(ResourceSetBasedAllContainersStateProvider.class)
+        LoggerManager.getLogger(ResourceSetBasedAllContainersStateProvider.class)
                 .setLevel(Level.WARN);
-        Logger.getLogger(AbstractCleaningLinker.class)
+        LoggerManager.getLogger(AbstractCleaningLinker.class)
                 .setLevel(Level.WARN);
 
         logger.info("Successfully initialized standalone log4j for the data flow analysis.");

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/core/AbstractVertex.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.core;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 /**
  * This class represents an abstract vertex in a {@link AbstractTransposeFlowGraph}. An abstract vertex represents an
@@ -12,7 +13,7 @@ import org.apache.log4j.Logger;
  * @param <T> Type parameter representing the type of the stored object
  */
 public abstract class AbstractVertex<T> {
-    private final Logger logger = Logger.getLogger(AbstractVertex.class);
+    private final Logger logger = LoggerManager.getLogger(AbstractVertex.class);
 
     protected final T referencedElement;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisConstraint.java
@@ -14,6 +14,7 @@ import org.dataflowanalysis.analysis.dsl.result.DSLConstraintTrace;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -29,7 +30,7 @@ public class AnalysisConstraint {
     private static final String SUCCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
     private static final String OMMITED_TRANSPOSE_FLOW_GRAPH = "Transpose flow graph %s did not contain any violations. Omitting!";
 
-    private final Logger logger = Logger.getLogger(AnalysisConstraint.class);
+    private final Logger logger = LoggerManager.getLogger(AnalysisConstraint.class);
     private final String name;
     private final DataSourceSelectors dataSourceSelectors;
     private final VertexSourceSelectors vertexSourceSelectors;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisQuery.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/AnalysisQuery.java
@@ -11,16 +11,17 @@ import org.dataflowanalysis.analysis.dsl.result.DSLConstraintTrace;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 /**
  * Represents an analysis query created by the DSL
  */
 public class AnalysisQuery {
     private static final String FAILED_MATCHING_MESSAGE = "Vertex %s failed to match selector %s";
-    private static final String SUCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
+    private static final String SUCCEEDED_MATCHING_MESSAGE = "Vertex %s matched all selectors";
     private static final String OMMITED_TRANSPOSE_FLOW_GRAPH = "Transpose flow graph %s did not contain any queried vertices. Omitting!";
 
-    private final Logger logger = Logger.getLogger(AnalysisQuery.class);
+    private final Logger logger = LoggerManager.getLogger(AnalysisQuery.class);
     private final List<AbstractSelector> flowSource;
     private final List<ConditionalSelector> selectors;
     private final DSLContext context;
@@ -61,7 +62,7 @@ public class AnalysisQuery {
                     }
                 }
                 if (matched) {
-                    logger.debug(String.format(SUCEEDED_MATCHING_MESSAGE, vertex));
+                    logger.debug(String.format(SUCCEEDED_MATCHING_MESSAGE, vertex));
                     matchedVertices.add(vertex);
                 }
             }

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -70,7 +70,7 @@ public class ConditionalSelectors extends AbstractParseable {
         if (string.invalid()) {
             return ParseResult.error("Unexpected end of input!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         List<ConditionalSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
             string.skipWhitespace();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/ConditionalSelectors.java
@@ -8,6 +8,7 @@ import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.selectors.ConditionalSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.EmptySetOperationConditionalSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableConditionalSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -16,7 +17,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  */
 public class ConditionalSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "where";
-    private static final Logger logger = Logger.getLogger(ConditionalSelectors.class);
+    private static final Logger logger = LoggerManager.getLogger(ConditionalSelectors.class);
 
     private final List<ConditionalSelector> selectors;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -9,6 +9,7 @@ import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.DataCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VariableNameSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -16,7 +17,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  * Represents the source data {@link AbstractSelector} matched by an {@link AnalysisConstraint}
  */
 public class DataSourceSelectors extends AbstractParseable {
-    private static final Logger logger = Logger.getLogger(DataSourceSelectors.class);
+    private static final Logger logger = LoggerManager.getLogger(DataSourceSelectors.class);
     private static final String DSL_KEYWORD = "data";
 
     private final List<AbstractSelector> selectors;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/DataSourceSelectors.java
@@ -74,7 +74,7 @@ public class DataSourceSelectors extends AbstractParseable {
             string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
             string.skipWhitespace();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -10,6 +10,7 @@ import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsListSele
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexNameSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -18,7 +19,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  */
 public class VertexDestinationSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
-    private static final Logger logger = Logger.getLogger(VertexDestinationSelectors.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexDestinationSelectors.class);
 
     private final List<AbstractSelector> selectors;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexDestinationSelectors.java
@@ -75,7 +75,7 @@ public class VertexDestinationSelectors extends AbstractParseable {
             string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
             string.skipWhitespace();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -9,6 +9,7 @@ import org.dataflowanalysis.analysis.dsl.selectors.AbstractSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsListSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexCharacteristicsSelector;
 import org.dataflowanalysis.analysis.dsl.selectors.VertexTypeSelector;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -17,7 +18,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  */
 public class VertexSourceSelectors extends AbstractParseable {
     private static final String DSL_KEYWORD = "vertex";
-    private static final Logger logger = Logger.getLogger(VertexSourceSelectors.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexSourceSelectors.class);
 
     private final List<AbstractSelector> selectors;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/VertexSourceSelectors.java
@@ -74,7 +74,7 @@ public class VertexSourceSelectors extends AbstractParseable {
             string.setPosition(position);
             return ParseResult.error("Unexpected end of input!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         List<AbstractSelector> selectors = new ArrayList<>();
         while (!string.invalid()) {
             string.skipWhitespace();

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
@@ -8,6 +8,7 @@ import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.context.DSLContextKey;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -16,7 +17,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  * {@link ConstraintVariableReference} that is not a constant
  */
 public final class CharacteristicsSelectorData extends AbstractParseable {
-    private static final Logger logger = Logger.getLogger(CharacteristicsSelectorData.class);
+    private static final Logger logger = LoggerManager.getLogger(CharacteristicsSelectorData.class);
     private final ConstraintVariableReference characteristicType;
     private final ConstraintVariableReference characteristicValue;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/CharacteristicsSelectorData.java
@@ -94,7 +94,7 @@ public final class CharacteristicsSelectorData extends AbstractParseable {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse characteristic selector data from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         ParseResult<ConstraintVariableReference> characteristicType = ConstraintVariableReference.fromString(string);
         if (characteristicType.failed()) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -9,11 +9,12 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class DataCharacteristicListSelector extends DataSelector {
-    private static final Logger logger = Logger.getLogger(DataCharacteristicListSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(DataCharacteristicListSelector.class);
 
     private final List<CharacteristicsSelectorData> dataCharacteristics;
     private final boolean inverted;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicListSelector.java
@@ -100,7 +100,7 @@ public class DataCharacteristicListSelector extends DataSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse characteristic list selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -7,11 +7,12 @@ import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class DataCharacteristicsSelector extends DataSelector {
-    private static final Logger logger = Logger.getLogger(DataCharacteristicsSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(DataCharacteristicsSelector.class);
 
     private final CharacteristicsSelectorData dataCharacteristic;
     private final boolean inverted;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/DataCharacteristicsSelector.java
@@ -90,7 +90,7 @@ public class DataCharacteristicsSelector extends DataSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse data characteristic selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -5,12 +5,13 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class EmptySetOperationConditionalSelector implements ConditionalSelector {
     private static final String DSL_KEYWORD = "empty";
-    private static final Logger logger = Logger.getLogger(EmptySetOperationConditionalSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(EmptySetOperationConditionalSelector.class);
 
     private final SetOperation setOperation;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/EmptySetOperationConditionalSelector.java
@@ -56,7 +56,7 @@ public class EmptySetOperationConditionalSelector implements ConditionalSelector
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse empty set operation from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -7,12 +7,13 @@ import org.dataflowanalysis.analysis.dsl.AbstractParseable;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.context.DSLContextKey;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariableReference;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class Intersection extends AbstractParseable implements SetOperation {
     private static final String DSL_KEYWORD = "intersection";
-    private static final Logger logger = Logger.getLogger(Intersection.class);
+    private static final Logger logger = LoggerManager.getLogger(Intersection.class);
 
     private final ConstraintVariableReference firstVariable;
     private final ConstraintVariableReference secondVariable;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/Intersection.java
@@ -71,7 +71,7 @@ public class Intersection extends AbstractParseable implements SetOperation {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse intersection from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -55,7 +55,7 @@ public class VariableNameSelector extends DataSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse variable name selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         if (!string.startsWith(DSL_KEYWORD)) {
             return string.expect(DSL_KEYWORD);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VariableNameSelector.java
@@ -3,12 +3,13 @@ package org.dataflowanalysis.analysis.dsl.selectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VariableNameSelector extends DataSelector {
     private static final String DSL_KEYWORD = "named";
-    private static final Logger logger = Logger.getLogger(VariableNameSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(VariableNameSelector.class);
 
     private final String variableName;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
@@ -134,7 +134,7 @@ public class VertexCharacteristicsListSelector extends VertexSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot vertex characteristic list selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsListSelector.java
@@ -10,11 +10,12 @@ import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VertexCharacteristicsListSelector extends VertexSelector {
-    private static final Logger logger = Logger.getLogger(VertexCharacteristicsListSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexCharacteristicsListSelector.class);
 
     private final List<CharacteristicsSelectorData> vertexCharacteristics;
     private final boolean inverted;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -117,7 +117,7 @@ public class VertexCharacteristicsSelector extends VertexSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse vertex characteristic selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexCharacteristicsSelector.java
@@ -8,11 +8,12 @@ import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
 import org.dataflowanalysis.analysis.dsl.variable.ConstraintVariable;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VertexCharacteristicsSelector extends VertexSelector {
-    private static final Logger logger = Logger.getLogger(VertexCharacteristicsSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexCharacteristicsSelector.class);
 
     private final CharacteristicsSelectorData vertexCharacteristics;
     private final boolean inverted;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexNameSelector.java
@@ -70,7 +70,7 @@ public class VertexNameSelector extends VertexSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse vertex name selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = false;
         if (string.startsWith(DSL_INVERTED_SYMBOL)) {

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexNameSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexNameSelector.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.analysis.dsl.selectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 import org.palladiosimulator.pcm.core.entity.Entity;
@@ -10,7 +11,7 @@ import tools.mdsd.modelingfoundations.identifier.NamedElement;
 
 public class VertexNameSelector extends VertexSelector {
     private static final String DSL_KEYWORD = "named";
-    private static final Logger logger = Logger.getLogger(VertexNameSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexNameSelector.class);
 
     private final String name;
     private final boolean inverted;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -70,7 +70,7 @@ public class VertexTypeSelector extends VertexSelector {
         if (string.invalid() || string.empty()) {
             return ParseResult.error("Cannot parse vertex type selector from empty or invalid string!");
         }
-        logger.info("Parsing: " + string.getString());
+        logger.debug("Parsing: " + string.getString());
         int position = string.getPosition();
         boolean inverted = string.getString()
                 .startsWith(DSL_INVERTED_SYMBOL);

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/selectors/VertexTypeSelector.java
@@ -3,11 +3,12 @@ package org.dataflowanalysis.analysis.dsl.selectors;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.dsl.context.DSLContext;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
 public class VertexTypeSelector extends VertexSelector {
-    private static final Logger logger = Logger.getLogger(VertexTypeSelector.class);
+    private static final Logger logger = LoggerManager.getLogger(VertexTypeSelector.class);
     private static final String DSL_KEYWORD = "type";
 
     private final VertexType vertexType;

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dsl.AbstractParseable;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 
@@ -13,7 +14,7 @@ import org.dataflowanalysis.analysis.utils.StringView;
  */
 public final class ConstraintVariableReference extends AbstractParseable {
     private static final String DSL_VARIABLE_SIGN = "$";
-    private static final Logger logger = Logger.getLogger(ConstraintVariableReference.class);
+    private static final Logger logger = LoggerManager.getLogger(ConstraintVariableReference.class);
     private final String name;
     private final Optional<List<String>> values;
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/dsl/variable/ConstraintVariableReference.java
@@ -83,7 +83,7 @@ public final class ConstraintVariableReference extends AbstractParseable {
             return ParseResult.error("Invalid variable: Expected any string!");
         }
         String string = split[0];
-        logger.info("Parsing: " + string);
+        logger.debug("Parsing: " + string);
         stringView.advance(string.length());
         if (string.startsWith(DSL_VARIABLE_SIGN)) {
             if (string.substring(1)

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/resource/ResourceProvider.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
@@ -27,7 +28,7 @@ import org.palladiosimulator.pcm.core.entity.Entity;
  * methods for working with loaded resources, like finding specific model elements.
  */
 public abstract class ResourceProvider {
-    private static final Logger logger = Logger.getLogger(ResourceProvider.class);
+    private static final Logger logger = LoggerManager.getLogger(ResourceProvider.class);
 
     protected final ResourceSet resources = new ResourceSetImpl();
 

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/LoggerManager.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/LoggerManager.java
@@ -1,0 +1,41 @@
+package org.dataflowanalysis.analysis.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.EnhancedPatternLayout;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+public class LoggerManager {
+    private static final Level DEFAULT_LOG_LEVEL = Level.INFO;
+
+    private static final LoggerManager instance = new LoggerManager();
+
+    private final List<Logger> loggers;
+
+    public LoggerManager() {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure(new ANSIConsoleLogger(new EnhancedPatternLayout("%-6r [%p] %-35C{1} - %m%n")));
+        this.loggers = new ArrayList<>();
+    }
+
+    public void setLevel(Level level) {
+        this.loggers.forEach(it -> it.setLevel(level));
+    }
+
+    public void resetLevel() {
+        this.loggers.forEach(it -> it.setLevel(DEFAULT_LOG_LEVEL));
+    }
+
+    public static Logger getLogger(Class<?> clazz) {
+        Logger logger = Logger.getLogger(clazz);
+        logger.setLevel(DEFAULT_LOG_LEVEL);
+        instance.loggers.add(logger);
+        return logger;
+    }
+
+    public static LoggerManager getInstance() {
+        return instance;
+    }
+}

--- a/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/LoggerManager.java
+++ b/bundles/org.dataflowanalysis.analysis/src/org/dataflowanalysis/analysis/utils/LoggerManager.java
@@ -14,7 +14,7 @@ public class LoggerManager {
 
     private final List<Logger> loggers;
 
-    public LoggerManager() {
+    private LoggerManager() {
         BasicConfigurator.resetConfiguration();
         BasicConfigurator.configure(new ANSIConsoleLogger(new EnhancedPatternLayout("%-6r [%p] %-35C{1} - %m%n")));
         this.loggers = new ArrayList<>();
@@ -22,6 +22,15 @@ public class LoggerManager {
 
     public void setLevel(Level level) {
         this.loggers.forEach(it -> it.setLevel(level));
+    }
+
+    public void setLevel(Level level, Class<?> clazz) {
+        Logger logger = this.loggers.stream()
+                .filter(it -> it.getName()
+                        .equals(clazz.getName()))
+                .findAny()
+                .orElseThrow();
+        logger.setLevel(level);
     }
 
     public void resetLevel() {

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/Converter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/Converter.java
@@ -1,12 +1,13 @@
 package org.dataflowanalysis.converter;
 
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 /**
  * This class represents an interface all converters should implement
  */
 public abstract class Converter {
-    protected final Logger logger = Logger.getLogger(Converter.class);
+    protected final Logger logger = LoggerManager.getLogger(Converter.class);
 
     /**
      * Converts the given {@link ConverterModel} input model to the given {@link ConverterModel} output model according to

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/ConverterModel.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/ConverterModel.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.converter.util.FileNameOnlyURIHandler;
 import org.dataflowanalysis.converter.util.PathUtils;
 import org.eclipse.emf.common.util.URI;
@@ -17,7 +18,7 @@ import org.eclipse.emf.ecore.xmi.impl.XMLResourceFactoryImpl;
  * Abstract representation for an input to an {@link Converter}
  */
 public abstract class ConverterModel {
-    protected static final Logger logger = Logger.getLogger(ConverterModel.class);
+    protected static final Logger logger = LoggerManager.getLogger(ConverterModel.class);
 
     private final ModelType modelType;
 

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/dfd2web/DFD2WebConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/dfd2web/DFD2WebConverter.java
@@ -18,6 +18,7 @@ import org.dataflowanalysis.analysis.dfd.core.DFDFlowGraphCollection;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.simple.DFDSimpleTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dsl.AnalysisConstraint;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.converter.Converter;
 import org.dataflowanalysis.converter.ConverterModel;
 import org.dataflowanalysis.converter.web2dfd.BehaviorConverter;
@@ -39,7 +40,7 @@ import org.dataflowanalysis.dfd.dataflowdiagram.Process;
  * Converts data flow diagrams and dictionaries to the web editor format
  */
 public class DFD2WebConverter extends Converter {
-    private final Logger logger = Logger.getLogger(DFD2WebConverter.class);
+    private final Logger logger = LoggerManager.getLogger(DFD2WebConverter.class);
 
     private final static String DELIMITER_PIN_NAME = "|";
     private final static String DELIMITER_MULTI_PIN = ",";

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/interactive/StandaloneConvertTask.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/interactive/StandaloneConvertTask.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Scanner;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.converter.Converter;
 import org.dataflowanalysis.converter.ConverterModel;
 import org.dataflowanalysis.converter.ModelType;
@@ -20,7 +21,7 @@ import org.dataflowanalysis.converter.util.PathUtils;
 import org.dataflowanalysis.converter.web2dfd.WebEditorConverterModel;
 
 public class StandaloneConvertTask {
-    private static final Logger logger = Logger.getLogger(StandaloneConvertTask.class);
+    private static final Logger logger = LoggerManager.getLogger(StandaloneConvertTask.class);
 
     /**
      * Entry point of the interactive converter. Can be run interactively without any command line parameter or directly via

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/pcm2dfd/PCMConverterModel.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/pcm2dfd/PCMConverterModel.java
@@ -1,7 +1,6 @@
 package org.dataflowanalysis.converter.pcm2dfd;
 
 import java.util.Scanner;
-import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.FlowGraphCollection;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
@@ -37,7 +36,6 @@ public class PCMConverterModel extends ConverterModel {
                 .useNodeCharacteristicsModel(nodeCharPath)
                 .build();
 
-        analysis.setLoggerLevel(Level.TRACE);
         analysis.initializeAnalysis();
         this.flowGraphCollection = analysis.findFlowGraphs();
         this.flowGraphCollection.evaluate();
@@ -53,7 +51,6 @@ public class PCMConverterModel extends ConverterModel {
                         URI.createFileURI(nodeCharPath)))
                 .build();
 
-        analysis.setLoggerLevel(Level.TRACE);
         analysis.initializeAnalysis();
         this.flowGraphCollection = analysis.findFlowGraphs();
         this.flowGraphCollection.evaluate();
@@ -71,7 +68,6 @@ public class PCMConverterModel extends ConverterModel {
                         URI.createFileURI(nodeCharPath)))
                 .build();
 
-        analysis.setLoggerLevel(Level.TRACE);
         analysis.initializeAnalysis();
         this.flowGraphCollection = analysis.findFlowGraphs();
         this.flowGraphCollection.evaluate();

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/web2dfd/BehaviorConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/web2dfd/BehaviorConverter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.dfd.datadictionary.AND;
 import org.dataflowanalysis.dfd.datadictionary.DataDictionary;
 import org.dataflowanalysis.dfd.datadictionary.Label;
@@ -24,7 +25,7 @@ public class BehaviorConverter {
     private final datadictionaryFactory ddFactory = datadictionaryFactory.eINSTANCE;
     private final DataDictionary dataDictionary;
 
-    private final Logger logger = Logger.getLogger(BehaviorConverter.class);
+    private final Logger logger = LoggerManager.getLogger(BehaviorConverter.class);
 
     private final String LOGICAL_AND = "&&";
     private final String LOGICAL_OR = "||";

--- a/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/web2dfd/Web2DFDConverter.java
+++ b/bundles/org.dataflowanalysis.converter/src/org/dataflowanalysis/converter/web2dfd/Web2DFDConverter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.converter.Converter;
 import org.dataflowanalysis.converter.ConverterModel;
 import org.dataflowanalysis.converter.dfd2web.DataFlowDiagramAndDictionary;
@@ -29,7 +30,7 @@ import org.dataflowanalysis.dfd.dataflowdiagram.Node;
 import org.dataflowanalysis.dfd.dataflowdiagram.dataflowdiagramFactory;
 
 public class Web2DFDConverter extends Converter {
-    private final static Logger logger = Logger.getLogger(Web2DFDConverter.class);
+    private final static Logger logger = LoggerManager.getLogger(Web2DFDConverter.class);
 
     protected final static String DELIMITER_PIN_NAME = "|";
     protected final static String DELIMITER_MULTI_PIN = ",";

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/DemoTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/DemoTest.java
@@ -22,6 +22,7 @@ import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.analysis.pcm.core.PCMFlowGraphCollection;
 import org.dataflowanalysis.analysis.tests.integration.constraint.ConstraintTest;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.examplemodels.Activator;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ public class DemoTest {
     protected PCMDataFlowConfidentialityAnalysis pcmAnalysis;
     protected DFDConfidentialityAnalysis dfdAnalysis;
 
-    private final Logger logger = Logger.getLogger(ConstraintTest.class);
+    private final Logger logger = LoggerManager.getLogger(ConstraintTest.class);
 
     @BeforeAll
     public void initializePCMAnalysis() {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/BaseTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/BaseTest.java
@@ -4,7 +4,6 @@ import static org.dataflowanalysis.analysis.tests.integration.AnalysisUtils.TEST
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
 import org.dataflowanalysis.examplemodels.Activator;
@@ -26,7 +25,6 @@ public class BaseTest {
 
         onlineShopAnalysis = this.initializeAnalysis(usageModelPath, allocationPath, nodeCharacteristicsPath);
         onlineShopAnalysis.initializeAnalysis();
-        onlineShopAnalysis.setLoggerLevel(Level.TRACE);
     }
 
     @BeforeAll
@@ -37,7 +35,6 @@ public class BaseTest {
 
         internationalOnlineShopAnalysis = this.initializeAnalysis(usageModelPath, allocationPath, nodeCharacteristicsPath);
         internationalOnlineShopAnalysis.initializeAnalysis();
-        internationalOnlineShopAnalysis.setLoggerLevel(Level.TRACE);
     }
 
     @BeforeAll
@@ -48,7 +45,6 @@ public class BaseTest {
 
         travelPlannerAnalysis = this.initializeAnalysis(usageModelPath, allocationPath, nodeCharacteristicsPath);
         travelPlannerAnalysis.initializeAnalysis();
-        travelPlannerAnalysis.setLoggerLevel(Level.TRACE);
     }
 
     protected PCMDataFlowConfidentialityAnalysis initializeAnalysis(Path usagePath, Path allocationPath, Path nodePath) {

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/ExampleModelsTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/ExampleModelsTest.java
@@ -16,6 +16,7 @@ import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dsl.result.DSLResult;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysisBuilder;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.examplemodels.results.ExampleModelResult;
 import org.dataflowanalysis.examplemodels.results.ExpectedCharacteristic;
 import org.dataflowanalysis.examplemodels.results.ExpectedViolation;
@@ -45,7 +46,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class ExampleModelsTest {
-    private final Logger logger = Logger.getLogger(ExampleModelsTest.class);
+    private final Logger logger = LoggerManager.getLogger(ExampleModelsTest.class);
 
     private static Stream<Arguments> providePCMExampleModelViolations() {
         return Stream.of(Arguments.of(new BankBranchesResult()), Arguments.of(new BranchingOnlineShopResult()), Arguments.of(new CompositeResult()),

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintFeatureTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintFeatureTest.java
@@ -4,17 +4,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.pcm.PCMDataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.pcm.core.PCMFlowGraphCollection;
 import org.dataflowanalysis.analysis.pcm.core.user.CallingUserPCMVertex;
 import org.dataflowanalysis.analysis.pcm.core.user.UserPCMVertex;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ConstraintFeatureTest extends ConstraintTest {
-    private final Logger logger = Logger.getLogger(ConstraintFeatureTest.class);
+    private final Logger logger = LoggerManager.getLogger(ConstraintFeatureTest.class);
 
     /**
      * Test determining whether node characteristics work correctly
@@ -30,7 +30,6 @@ public class ConstraintFeatureTest extends ConstraintTest {
         PCMFlowGraphCollection flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
 
-        logger.setLevel(Level.TRACE);
         var results = analysis.queryDataFlow(flowGraph.getTransposeFlowGraphs()
                 .get(0), node -> {
                     printNodeInformation(node);
@@ -60,7 +59,6 @@ public class ConstraintFeatureTest extends ConstraintTest {
         PCMFlowGraphCollection flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
 
-        logger.setLevel(Level.TRACE);
         var results = analysis.queryDataFlow(flowGraph.getTransposeFlowGraphs()
                 .get(0), node -> {
                     printNodeInformation(node);
@@ -90,7 +88,6 @@ public class ConstraintFeatureTest extends ConstraintTest {
         PCMFlowGraphCollection flowGraph = analysis.findFlowGraphs();
         flowGraph.evaluate();
 
-        logger.setLevel(Level.TRACE);
         var results = analysis.queryDataFlow(flowGraph.getTransposeFlowGraphs()
                 .get(0), node -> {
                     printNodeInformation(node);

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintResultTest.java
@@ -10,7 +10,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.core.DataCharacteristic;
@@ -103,7 +102,6 @@ public class ConstraintResultTest extends ConstraintTest {
      */
     @Test
     public void travelPlannerTestConstraintResults() {
-        travelPlannerAnalysis.setLoggerLevel(Level.TRACE);
         Predicate<AbstractVertex<?>> constraint = this::travelPlannerCondition;
         List<ConstraintData> constraintData = ConstraintViolations.travelPlannerViolations;
         testAnalysis(travelPlannerAnalysis, constraint, constraintData);
@@ -116,7 +114,6 @@ public class ConstraintResultTest extends ConstraintTest {
      */
     @Test
     public void internationalOnlineShopTestConstraintResults() {
-        internationalOnlineShopAnalysis.setLoggerLevel(Level.TRACE);
         Predicate<AbstractVertex<?>> constraint = this::internationalOnlineShopCondition;
         List<ConstraintData> constraintData = ConstraintViolations.internationalOnlineShopViolations;
         testAnalysis(internationalOnlineShopAnalysis, constraint, constraintData);
@@ -133,7 +130,6 @@ public class ConstraintResultTest extends ConstraintTest {
                 Paths.get("models", "pcm", "MultipleDeployments", "default.usagemodel"),
                 Paths.get("models", "pcm", "MultipleDeployments", "default.allocation"),
                 Paths.get("models", "pcm", "MultipleDeployments", "default.nodecharacteristics"));
-        analysis.setLoggerLevel(Level.TRACE);
         Predicate<AbstractVertex<?>> constraint = this::internationalOnlineShopCondition;
         List<ConstraintData> constraintData = ConstraintViolations.multipleResourcesViolations;
         testAnalysis(analysis, constraint, constraintData);
@@ -151,7 +147,6 @@ public class ConstraintResultTest extends ConstraintTest {
                 Paths.get("models", "pcm", "VariableReturn", "default.allocation"),
                 Paths.get("models", "pcm", "VariableReturn", "default.nodecharacteristics"));
         Predicate<AbstractVertex<?>> constraint = this::returnCondition;
-        returnAnalysis.setLoggerLevel(Level.TRACE);
         List<ConstraintData> constraintData = ConstraintViolations.returnViolations;
         testAnalysis(returnAnalysis, constraint, constraintData);
     }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/constraint/ConstraintTest.java
@@ -6,10 +6,11 @@ import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.tests.integration.BaseTest;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 public class ConstraintTest extends BaseTest {
 
-    private final Logger logger = Logger.getLogger(ConstraintTest.class);
+    private final Logger logger = LoggerManager.getLogger(ConstraintTest.class);
 
     /**
      * Prints a violation with detailed information about the node where it occurred with its data characteristics and

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dfd/MicroSecEndTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dfd/MicroSecEndTest.java
@@ -21,6 +21,7 @@ import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.core.DFDTransposeFlowGraphFinder;
 import org.dataflowanalysis.analysis.dfd.core.DFDVertex;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.examplemodels.Activator;
 import org.dataflowanalysis.examplemodels.TuhhModels;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ public class MicroSecEndTest {
     public static final String PROJECT_NAME = "org.dataflowanalysis.examplemodels";
     public static final String location = Paths.get("scenarios", "dfd", "TUHH-Models")
             .toString();
-    private final Logger logger = Logger.getLogger(MicroSecEndTest.class);
+    private final Logger logger = LoggerManager.getLogger(MicroSecEndTest.class);
 
     private DFDConfidentialityAnalysis buildAnalysis(String name) {
         var dataFlowDiagramPath = name + ".dataflowdiagram";

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dfd/simple/DFDSimpleTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dfd/simple/DFDSimpleTest.java
@@ -5,13 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Paths;
+import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.dfd.DFDConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.dfd.DFDDataFlowAnalysisBuilder;
 import org.dataflowanalysis.analysis.dfd.simple.DFDSimpleTransposeFlowGraphFinder;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.examplemodels.Activator;
 import org.junit.jupiter.api.Test;
 
 public class DFDSimpleTest {
+    private final Logger logger = LoggerManager.getLogger(DFDSimpleTest.class);
+
     private DFDConfidentialityAnalysis analysis;
 
     @Test
@@ -30,7 +34,7 @@ public class DFDSimpleTest {
 
         this.analysis.initializeAnalysis();
         var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-        System.out.println(exception.getMessage());
+        logger.info(exception.getMessage());
         assertEquals("DFD not simple: outPin not requiring all InPins", exception.getMessage());
     }
 
@@ -50,7 +54,7 @@ public class DFDSimpleTest {
 
         this.analysis.initializeAnalysis();
         var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-        System.out.println(exception.getMessage());
+        logger.info(exception.getMessage());
         assertEquals("DFD not simple: Number of flows to inpin not 1", exception.getMessage());
     }
 
@@ -70,7 +74,7 @@ public class DFDSimpleTest {
 
         this.analysis.initializeAnalysis();
         var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-        System.out.println(exception.getMessage());
+        logger.info(exception.getMessage());
         assertEquals("DFD not simple: Dead output pin", exception.getMessage());
     }
 
@@ -90,7 +94,7 @@ public class DFDSimpleTest {
 
         this.analysis.initializeAnalysis();
         var exception = assertThrows(IllegalArgumentException.class, () -> analysis.findFlowGraphs());
-        System.out.println(exception.getMessage());
+        logger.info(exception.getMessage());
         assertEquals("DFD not simple: All outgoing flows from one pin must have the same name", exception.getMessage());
     }
 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/dsl/DSLResultTest.java
@@ -3,7 +3,6 @@ package org.dataflowanalysis.analysis.tests.integration.dsl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.DataFlowConfidentialityAnalysis;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
@@ -26,13 +25,14 @@ import org.dataflowanalysis.analysis.pcm.dsl.PCMVertexType;
 import org.dataflowanalysis.analysis.tests.integration.BaseTest;
 import org.dataflowanalysis.analysis.tests.integration.constraint.data.ConstraintData;
 import org.dataflowanalysis.analysis.tests.integration.constraint.data.ConstraintViolations;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.analysis.utils.ParseResult;
 import org.dataflowanalysis.analysis.utils.StringView;
 import org.junit.jupiter.api.Test;
 import tools.mdsd.modelingfoundations.identifier.NamedElement;
 
 public class DSLResultTest extends BaseTest {
-    private static final Logger logger = Logger.getLogger(DSLResultTest.class);
+    private static final Logger logger = LoggerManager.getLogger(DSLResultTest.class);
 
     @Test
     public void testDSL() {
@@ -126,9 +126,7 @@ public class DSLResultTest extends BaseTest {
             if (violations.contains(vertex)) {
                 continue;
             }
-            logger.error("Should have matched vertex: " + vertex.createPrintableNodeInformation());
         }
-        logger.setLevel(Level.TRACE);
         violations.forEach(vertex -> logger.trace(vertex.createPrintableNodeInformation()));
         assertEquals(42, violations.size());
         assertEquals(constraint.toString(), AnalysisConstraint.fromString(new StringView(constraint.toString()))
@@ -159,9 +157,7 @@ public class DSLResultTest extends BaseTest {
             if (violations.contains(vertex)) {
                 continue;
             }
-            logger.error("Should have matched vertex: " + vertex.createPrintableNodeInformation());
         }
-        logger.setLevel(Level.TRACE);
         violations.forEach(vertex -> logger.trace(vertex.createPrintableNodeInformation()));
         assertEquals(34, violations.size());
         assertEquals(constraint.toString(), AnalysisConstraint.fromString(new StringView(constraint.toString()))
@@ -192,9 +188,7 @@ public class DSLResultTest extends BaseTest {
                     .equalsIgnoreCase("DatabaseLoadInventory")) {
                 continue;
             }
-            logger.error("Should not have matched vertex: " + vertex.createPrintableNodeInformation());
         }
-        logger.setLevel(Level.TRACE);
         violations.forEach(vertex -> logger.trace(vertex.createPrintableNodeInformation()));
         assertEquals(2 * 2, violations.size());
         assertEquals(constraint.toString(), AnalysisConstraint.fromString(new StringView(constraint.toString()))
@@ -226,7 +220,6 @@ public class DSLResultTest extends BaseTest {
                 .map(DSLResult::getMatchedVertices)
                 .flatMap(List::stream)
                 .toList();
-        logger.setLevel(Level.TRACE);
         violations.forEach(vertex -> logger.trace(vertex.createPrintableNodeInformation()));
         assertEquals(expectedResults.size(), violations.size());
     }

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/propagation/LabelPropagationTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/propagation/LabelPropagationTest.java
@@ -5,7 +5,6 @@ import static org.dataflowanalysis.analysis.tests.integration.AnalysisUtils.asse
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.pcm.core.PCMFlowGraphCollection;
 import org.dataflowanalysis.analysis.tests.integration.BaseTest;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,6 @@ public class LabelPropagationTest extends BaseTest {
      */
     @Test
     public void travelPlannerCharacteristicsPresentTest() {
-        travelPlannerAnalysis.setLoggerLevel(Level.TRACE);
         PCMFlowGraphCollection flowGraph = travelPlannerAnalysis.findFlowGraphs();
         flowGraph.evaluate();
 
@@ -40,7 +38,6 @@ public class LabelPropagationTest extends BaseTest {
      */
     @Test
     public void internationalOnlineShopCharacteristicsPresentTest() {
-        internationalOnlineShopAnalysis.setLoggerLevel(Level.TRACE);
         PCMFlowGraphCollection flowGraph = internationalOnlineShopAnalysis.findFlowGraphs();
         flowGraph.evaluate();
 
@@ -61,7 +58,6 @@ public class LabelPropagationTest extends BaseTest {
      */
     @Test
     public void onlineShopCharacteristicsPresentTest() {
-        onlineShopAnalysis.setLoggerLevel(Level.TRACE);
         PCMFlowGraphCollection flowGraph = onlineShopAnalysis.findFlowGraphs();
         flowGraph.evaluate();
 

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/sequencefinder/ActionSequenceFinderTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/integration/sequencefinder/ActionSequenceFinderTest.java
@@ -6,14 +6,14 @@ import static org.dataflowanalysis.analysis.tests.integration.AnalysisUtils.asse
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.dataflowanalysis.analysis.pcm.core.PCMFlowGraphCollection;
 import org.dataflowanalysis.analysis.tests.integration.BaseTest;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.junit.jupiter.api.Test;
 
 public class ActionSequenceFinderTest extends BaseTest {
-    private final Logger logger = Logger.getLogger(ActionSequenceFinderTest.class);
+    private final Logger logger = LoggerManager.getLogger(ActionSequenceFinderTest.class);
 
     /**
      * Tests whether the analysis finds the correct amount of sequences
@@ -21,7 +21,6 @@ public class ActionSequenceFinderTest extends BaseTest {
     @Test
     public void testTravelPlannerCount() {
         PCMFlowGraphCollection flowGraph = travelPlannerAnalysis.findFlowGraphs();
-        travelPlannerAnalysis.setLoggerLevel(Level.TRACE);
         assertEquals(ActionSequenceFinderPaths.travelPlannerPaths.size(), flowGraph.getTransposeFlowGraphs()
                 .size(),
                 String.format("Expected two dataflow sequences, but found %s sequences", flowGraph.getTransposeFlowGraphs()
@@ -36,7 +35,6 @@ public class ActionSequenceFinderTest extends BaseTest {
     @Test
     public void testInternationalOnlineShopCount() {
         PCMFlowGraphCollection flowGraph = internationalOnlineShopAnalysis.findFlowGraphs();
-        internationalOnlineShopAnalysis.setLoggerLevel(Level.TRACE);
         assertEquals(ActionSequenceFinderPaths.internationalOnlineShopPaths.size(), flowGraph.getTransposeFlowGraphs()
                 .size(),
                 String.format("Expected two dataflow sequences, but found %s sequences", flowGraph.getTransposeFlowGraphs()
@@ -51,7 +49,6 @@ public class ActionSequenceFinderTest extends BaseTest {
     @Test
     public void testOnlineShopCount() {
         PCMFlowGraphCollection flowGraph = onlineShopAnalysis.findFlowGraphs();
-        onlineShopAnalysis.setLoggerLevel(Level.TRACE);
         assertEquals(ActionSequenceFinderPaths.onlineShopPaths.size(), flowGraph.getTransposeFlowGraphs()
                 .size(),
                 String.format("Expected two dataflow sequences, but found %s sequences", flowGraph.getTransposeFlowGraphs()

--- a/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/unit/VertexTest.java
+++ b/tests/org.dataflowanalysis.analysis.tests/src/org/dataflowanalysis/analysis/tests/unit/VertexTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.stream.Stream;
+import org.apache.log4j.Level;
 import org.dataflowanalysis.analysis.core.AbstractVertex;
 import org.dataflowanalysis.analysis.core.CharacteristicValue;
 import org.dataflowanalysis.analysis.tests.unit.mock.CharacteristicsFactory;
 import org.dataflowanalysis.analysis.tests.unit.mock.DummyCharacteristicValue;
 import org.dataflowanalysis.analysis.tests.unit.mock.DummyVertex;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -58,8 +60,12 @@ public class VertexTest {
         } catch (Exception e) {
             fail(e);
         }
+        LoggerManager.getInstance()
+                .setLevel(Level.OFF);
         assertThrowsExactly(IllegalArgumentException.class,
                 () -> vertex.setPropagationResult(incomingCharacteristics, outgoingCharacteristics, vertexCharacteristics));
+        LoggerManager.getInstance()
+                .resetLevel();
     }
 
     @Test

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/ConverterTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/ConverterTest.java
@@ -8,7 +8,7 @@ public class ConverterTest {
     protected static final String TEST_JSONS = Paths.get("models", "ConverterTest")
             .toString();
     protected static final String TEST_MODELS = "org.dataflowanalysis.examplemodels";
-    private final Logger logger = Logger.getLogger(ConverterTest.class);
+    private final Logger logger = LoggerManager.getLogger(ConverterTest.class);
 
     protected void cleanup(String path) {
         (new File(path)).delete();

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/ConverterTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/ConverterTest.java
@@ -3,6 +3,7 @@ package org.dataflowanalysis.converter.tests;
 import java.io.File;
 import java.nio.file.Paths;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 
 public class ConverterTest {
     protected static final String TEST_JSONS = Paths.get("models", "ConverterTest")

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipelineTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipelineTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
+import org.dataflowanalysis.analysis.utils.LoggerManager;
 import org.dataflowanalysis.converter.micro2dfd.Micro2DFDConverter;
 import org.dataflowanalysis.converter.micro2dfd.MicroConverterModel;
 import org.junit.jupiter.api.Disabled;

--- a/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipelineTest.java
+++ b/tests/org.dataflowanalysis.converter.tests/src/org/dataflowanalysis/converter/tests/TUHHPipelineTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class TUHHPipelineTest {
     public static Path converter;
-    private final Logger logger = Logger.getLogger(TUHHPipelineTest.class);
+    private final Logger logger = LoggerManager.getLogger(TUHHPipelineTest.class);
 
     public static final List<Integer> OUT_OF_SCOPE_VARIANTS = List.of(13, 14, 15, 16, 17);
 


### PR DESCRIPTION
This PR adds a dedicated `LoggerManager` that is responsible for creation of the Loggers with the correct logger level. Additionally, this finally allows setting the logger level globally